### PR TITLE
Nested activation of Conductor.ActiveItem

### DIFF
--- a/Stylet/ConductorBaseWithActiveItem.cs
+++ b/Stylet/ConductorBaseWithActiveItem.cs
@@ -39,6 +39,8 @@ namespace Stylet
             if (closePrevious)
                 this.CloseAndCleanUp(this.ActiveItem, this.DisposeChildren);
 
+            this._activeItem = newItem;
+
             if (newItem != null)
             {
                 this.EnsureItem(newItem);
@@ -49,8 +51,7 @@ namespace Stylet
                     ScreenExtensions.TryDeactivate(newItem);
             }
 
-            this._activeItem = newItem;
-            this.NotifyOfPropertyChange("ActiveItem");
+            this.NotifyOfPropertyChange(nameof(ActiveItem));
         }
 
         /// <summary>

--- a/StyletUnitTests/ConductorNavigatingTests.cs
+++ b/StyletUnitTests/ConductorNavigatingTests.cs
@@ -1,4 +1,5 @@
 ﻿using Moq;
+using Moq.Protected;
 using NUnit.Framework;
 using Stylet;
 using System;
@@ -284,6 +285,19 @@ namespace StyletUnitTests
 
             screen.Verify(x => x.Close());
             Assert.Null(this.conductor.ActiveItem);
+        }
+
+        [Test]
+        public void NestedActivateItemsResultsInLastActivatedItemActive()
+        {
+            var screen1 = new Mock<Screen>() { CallBase = true };
+            var screen2 = new Screen();
+            screen1.Protected().Setup("OnActivate").Callback(() => (this.conductor as MyConductor).ActivateItem(screen2));
+            (this.conductor as IScreenState).Activate();
+
+            this.conductor.ActivateItem(screen1.Object);
+
+            Assert.AreEqual(screen2, this.conductor.ActiveItem);
         }
     }
 }


### PR DESCRIPTION
Up to now, ScreenExtemsions.TryActivate(newItem) was called before Conductor.ActiveItem was set to the new item. This commit moves setting ActiveItem to before TryActivate(newItem) call. This allows for nested activation - that is, a scenario where newItem can "intercept" its activation and force parent Conductor to immediately activate another item inside its OnActivate() override, effectively skipping newItem without displaying it.
This basically solves #140 in a simpler manner, without the use of events.