### PR TITLE
Add a new template creating ViewModels and Views folders

### DIFF
--- a/StyletTemplates/templates/StyletApplication-CSharp-VVM/.template.config/template.json
+++ b/StyletTemplates/templates/StyletApplication-CSharp-VVM/.template.config/template.json
@@ -1,0 +1,16 @@
+{
+  "$schema": "http://json.schemastore.org/template",
+  "author": "Shuhua Gao",
+  "classifications": ["Common", "WPF", "MVVM", "Stylet"],
+  "name": "Stylet Application VVM",
+  "description": "A project for creating a .NET Core Stylet MVVM sApplications. This template creates two sub-folders, ViewModels and Views, inside the project directory.",
+  "identity": "Stylet.Templates.VVM",
+  "shortName": "stylet-vvm",
+  "tags": {
+    "language": "C#",
+    "type": "project"
+  },
+  "sourceName": "ProjectName",
+  "preferNameDirectory": true,
+  "defaultName": "StyletApp1"
+}

--- a/StyletTemplates/templates/StyletApplication-CSharp-VVM/App.xaml
+++ b/StyletTemplates/templates/StyletApplication-CSharp-VVM/App.xaml
@@ -1,0 +1,13 @@
+﻿<Application x:Class="ProjectName.App"
+             xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
+             xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
+             xmlns:s="https://github.com/canton7/Stylet"
+             xmlns:local="clr-namespace:ProjectName">
+    <Application.Resources>
+        <s:ApplicationLoader>
+            <s:ApplicationLoader.Bootstrapper>
+                <local:Bootstrapper/>
+            </s:ApplicationLoader.Bootstrapper>
+        </s:ApplicationLoader>
+    </Application.Resources>
+</Application>

--- a/StyletTemplates/templates/StyletApplication-CSharp-VVM/App.xaml.cs
+++ b/StyletTemplates/templates/StyletApplication-CSharp-VVM/App.xaml.cs
@@ -1,0 +1,17 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Configuration;
+using System.Data;
+using System.Linq;
+using System.Threading.Tasks;
+using System.Windows;
+
+namespace ProjectName
+{
+    /// <summary>
+    /// Interaction logic for App.xaml
+    /// </summary>
+    public partial class App : Application
+    {
+    }
+}

--- a/StyletTemplates/templates/StyletApplication-CSharp-VVM/Bootstrapper.cs
+++ b/StyletTemplates/templates/StyletApplication-CSharp-VVM/Bootstrapper.cs
@@ -1,0 +1,19 @@
+﻿using ProjectName.ViewModels;
+using Stylet;
+using StyletIoC;
+
+namespace ProjectName
+{
+    public class Bootstrapper : Bootstrapper<ShellViewModel>
+    {
+        protected override void ConfigureIoC(IStyletIoCBuilder builder)
+        {
+            // Configure the IoC container in here
+        }
+
+        protected override void Configure()
+        {
+            // Perform any other configuration before the application starts
+        }
+    }
+}

--- a/StyletTemplates/templates/StyletApplication-CSharp-VVM/ProjectName.csproj
+++ b/StyletTemplates/templates/StyletApplication-CSharp-VVM/ProjectName.csproj
@@ -1,0 +1,14 @@
+﻿<Project Sdk="Microsoft.NET.Sdk.WindowsDesktop">
+
+	<PropertyGroup>
+		<OutputType>WinExe</OutputType>
+		<TargetFramework>netcoreapp3.1</TargetFramework>
+		<RootNamespace>ProjectName</RootNamespace>
+		<UseWPF>true</UseWPF>
+	</PropertyGroup>
+
+	<ItemGroup>
+		<PackageReference Include="Stylet" Version="1.3.*" />
+	</ItemGroup>
+
+</Project>

--- a/StyletTemplates/templates/StyletApplication-CSharp-VVM/ViewModels/ShellViewModel.cs
+++ b/StyletTemplates/templates/StyletApplication-CSharp-VVM/ViewModels/ShellViewModel.cs
@@ -1,0 +1,8 @@
+﻿using Stylet;
+
+namespace ProjectName.ViewModels
+{
+    public class ShellViewModel : Screen
+    {
+    }
+}

--- a/StyletTemplates/templates/StyletApplication-CSharp-VVM/Views/ShellView.xaml
+++ b/StyletTemplates/templates/StyletApplication-CSharp-VVM/Views/ShellView.xaml
@@ -1,0 +1,16 @@
+﻿<Window x:Class="ProjectName.Views.ShellView"
+        xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
+        xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
+        xmlns:d="http://schemas.microsoft.com/expression/blend/2008"
+        xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
+        xmlns:s="https://github.com/canton7/Stylet"
+        xmlns:local="clr-namespace:ProjectName.ViewModels"
+        mc:Ignorable="d"
+        d:DataContext="{d:DesignInstance local:ShellViewModel}"
+        Title="Stylet Project" Height="450" Width="800">
+    <Grid>
+        <TextBlock FontSize="30" HorizontalAlignment="Center" VerticalAlignment="Center">
+            Hello Stylet!
+        </TextBlock>
+    </Grid>
+</Window>

--- a/StyletTemplates/templates/StyletApplication-CSharp-VVM/Views/ShellView.xaml.cs
+++ b/StyletTemplates/templates/StyletApplication-CSharp-VVM/Views/ShellView.xaml.cs
@@ -1,0 +1,15 @@
+﻿using System.Windows;
+
+namespace ProjectName.Views
+{
+    /// <summary>
+    /// Interaction logic for ShellView.xaml
+    /// </summary>
+    public partial class ShellView : Window
+    {
+        public ShellView()
+        {
+            InitializeComponent();
+        }
+    }
+}


### PR DESCRIPTION
Refer to #172. Also, this template supports the `-n` option of `dotnet new` to apply a custom project name, e.g., 
`dotnet new stylet-vvm -n HelloWorld`
 creates a project with name `HelloWorld`.