### PR TITLE
preventing potential "call base" errors in Conductor

### DIFF
--- a/Stylet/ConductorBaseWithActiveItem.cs
+++ b/Stylet/ConductorBaseWithActiveItem.cs
@@ -8,6 +8,25 @@ namespace Stylet;
 /// <typeparam name="T">Type of item being conducted</typeparam>
 public abstract class ConductorBaseWithActiveItem<T> : ConductorBase<T>, IHaveActiveItem<T> where T : class
 {
+    public ConductorBaseWithActiveItem()
+    {
+        this.Activated += (o, e) =>
+        {
+            ScreenExtensions.TryActivate(this.ActiveItem);
+        };
+
+        this.Deactivated += (o, e) =>
+        {
+            ScreenExtensions.TryDeactivate(this.ActiveItem);
+        };
+
+        this.Closed += (o, e) =>
+        {
+            this.CloseAndCleanUp(this.ActiveItem, this.DisposeChildren);
+        };
+    }
+
+
     private T _activeItem;
 
     /// <summary>
@@ -52,29 +71,5 @@ public abstract class ConductorBaseWithActiveItem<T> : ConductorBase<T>, IHaveAc
         }
 
         this.NotifyOfPropertyChange(nameof(this.ActiveItem));
-    }
-
-    /// <summary>
-    /// When we're activated, also activate the ActiveItem
-    /// </summary>
-    protected override void OnActivate()
-    {
-        ScreenExtensions.TryActivate(this.ActiveItem);
-    }
-
-    /// <summary>
-    /// When we're deactivated, also deactivate the ActiveItem
-    /// </summary>
-    protected override void OnDeactivate()
-    {
-        ScreenExtensions.TryDeactivate(this.ActiveItem);
-    }
-
-    /// <summary>
-    /// When we're closed, also close the ActiveItem
-    /// </summary>
-    protected override void OnClose()
-    {
-        this.CloseAndCleanUp(this.ActiveItem, this.DisposeChildren);
     }
 }


### PR DESCRIPTION
fixes #378

Up until now, when Conductor was activated, it called its ActiveItem's Activate() method from inside the Conductor's OnActivate() virtual method; Deactivate() and Close() worked the same way. If any of those OnXXX() virtual methods of a Conductor were overridden in derived class, and the user code forgot to manually call base method, it would lead to ActiveItem's Activate() method not being called.

This commit moves forwarding Activate calls to Conductor's Activated event; the same goes for Deactivated and Closed. This way the user doesn't have to call the base method when overriding OnActivate(), OnDeactivate and OnClose().