### PR TITLE
Bump System.Drawing.Common from 4.6.0 to 4.7.3 due to vulnerability

### DIFF
--- a/Stylet/Stylet.csproj
+++ b/Stylet/Stylet.csproj
@@ -31,7 +31,7 @@
   </PropertyGroup>
 
   <ItemGroup Condition="'$(TargetFramework)' != 'net452'">
-    <PackageReference Include="System.Drawing.Common" Version="4.6.0" />
+    <PackageReference Include="System.Drawing.Common" Version="4.7.3" />
   </ItemGroup>
   
   <ItemGroup>


### PR DESCRIPTION
https://github.com/advisories/GHSA-rxg9-xrhp-64gj

Merge to develop branch as per checklist but I would hope this gets pushed as 1.3.7 hotfix.